### PR TITLE
✨(feature): Apply authentication flows of React Navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,12 +2,15 @@ import 'react-native-gesture-handler';
 import React from 'react';
 import {NavigationContainer} from '@react-navigation/native';
 import Navigator from 'src/app/components/pages/Navigator';
+import AuthProvider from 'src/app/components/molecule/AuthProvider';
 
 export default function App() {
   return (
-    <NavigationContainer>
-      <Navigator />
-    </NavigationContainer>
+    <AuthProvider>
+      <NavigationContainer>
+        <Navigator />
+      </NavigationContainer>
+    </AuthProvider>
     // <View style={styles.container}>
     //   <Text>Open up App.tsx to start working on your app!</Text>
     // </View>

--- a/src/app/backend/Authn.ts
+++ b/src/app/backend/Authn.ts
@@ -21,7 +21,7 @@ class CognitoAuth {
     return await Auth.signIn(username, password);
   }
   async signOut() {
-    // TODO: これがグローバルサインアウトなのか不明
+    // ローカルサインアウト。グローバルサインアウトの場合はオプションをつける
     await Auth.signOut();
   }
   async signUp(form: SignUpForm) {

--- a/src/app/backend/Authn.ts
+++ b/src/app/backend/Authn.ts
@@ -16,9 +16,21 @@ const awsConfig = {
 Auth.configure(awsConfig);
 
 class CognitoAuth {
+  /** 現在のユーザセッション
+   *
+   * ※ 認証途中のユーザセッションを複数画面で引き継ぐ場合に利用する
+  */
+  userSession: CognitoUser | undefined;
+  constructor() {
+    // NOP
+  }
+
   async signIn(username: string, password: string) {
     console.log('SIGNIN', Auth.configure());
-    return await Auth.signIn(username, password);
+    const user = await Auth.signIn(username, password);
+    // 現在のユーザセッションを保持
+    this.userSession = user as CognitoUser;
+    return user;
   }
   async signOut() {
     // ローカルサインアウト。グローバルサインアウトの場合はオプションをつける
@@ -60,9 +72,10 @@ class CognitoAuth {
   async resendConfirmationCode(username: string) {
     await Auth.resendSignUp(username);
   }
-  async respondToAuthChallenge(user: CognitoUser, code: string) {
-    const result = Auth.confirmSignIn(user, code, 'SMS_MFA');
-    console.log(result);
+
+  async respondToAuthChallenge( code: string) {
+    const result = await Auth.confirmSignIn(this.userSession, code, 'SMS_MFA');
+    console.log('SMS_MFA_RESULT', result);
   }
 }
 export default new CognitoAuth;

--- a/src/app/backend/Authn.ts
+++ b/src/app/backend/Authn.ts
@@ -1,6 +1,7 @@
 import Auth from '@aws-amplify/auth';
 import {SignUpParams} from '@aws-amplify/auth/lib-esm/types';
 import {Config as AppConfig} from 'react-native-config';
+import {CognitoUser} from 'amazon-cognito-identity-js';
 
 const awsConfig = {
   Auth: {
@@ -43,19 +44,21 @@ class CognitoAuth {
   }
   // 現在のセッション情報を確認します
   async currentSession() {
-    const result = await Auth.currentSession();
-    // console.log("Current User", result);
-    if (result) {
-      console.log('SESSION EXISTS.');
-    } else {
-      if (result) {
-        console.log('SESSION NOT FOUND.');
-      }
+    try {
+      const result = await Auth.currentSession();
+      console.log('Current User', result);
+      return result;
+    } catch (error) {
+      console.log('currentSession', error);
     }
   }
   // サインアップ時の確認コードを再送します
   async resendConfirmationCode(username: string) {
     await Auth.resendSignUp(username);
+  }
+  async respondToAuthChallenge(user: CognitoUser, code: string) {
+    const result = Auth.confirmSignIn(user, code, 'SMS_MFA');
+    console.log(result);
   }
 }
 export default CognitoAuth;

--- a/src/app/backend/Authn.ts
+++ b/src/app/backend/Authn.ts
@@ -20,6 +20,10 @@ class CognitoAuth {
     console.log('SIGNIN', Auth.configure());
     return await Auth.signIn(username, password);
   }
+  async signOut() {
+    // TODO: これがグローバルサインアウトなのか不明
+    await Auth.signOut();
+  }
   async signUp(form: SignUpForm) {
     console.log(Auth.configure());
     const japanesePhoneNumberPrefix = '+81';
@@ -46,10 +50,10 @@ class CognitoAuth {
   async currentSession() {
     try {
       const result = await Auth.currentSession();
-      console.log('Current User', result);
+      console.debug('Current User', result);
       return result;
     } catch (error) {
-      console.log('currentSession', error);
+      console.log('Error in currentSession:', error);
     }
   }
   // サインアップ時の確認コードを再送します

--- a/src/app/backend/Authn.ts
+++ b/src/app/backend/Authn.ts
@@ -65,7 +65,7 @@ class CognitoAuth {
     console.log(result);
   }
 }
-export default CognitoAuth;
+export default new CognitoAuth;
 
 export type SignUpForm = {
   username: string;

--- a/src/app/components/molecule/AuthProvider.tsx
+++ b/src/app/components/molecule/AuthProvider.tsx
@@ -1,4 +1,4 @@
-import {createContext, useContext} from 'react';
+import React, {createContext, useContext, useReducer} from 'react';
 
 type State =
 | { status: 'Unauthenticated'; token: string|undefined }
@@ -30,20 +30,59 @@ const authReducer = (prevState: State, action: Action): State => {
         status: 'Unauthenticated',
         token: undefined,
       };
+    default:
+      return {
+        ...prevState,
+        status: 'Unauthenticated',
+        token: undefined,
+      };
   }
 };
+
+
 const AuthStateContext = createContext<State>({
   status: 'Unauthenticated',
   token: undefined,
 });
 
-const AuthDispatchContext = createContext<Dispatch | undefined>(undefined);
-export const useAuthState = () => {
+const AuthDispatchContext = createContext<Dispatch>(()=>{
+  return {type: 'COMPLETE_LOGOUT'};
+});
+
+/**
+ * 自作hooks
+ *
+ * @return {State} アプリの状態
+ */
+export const useAuthState = (): State => {
   const context = useContext(AuthStateContext);
   return context;
 };
 
-export const useAuthDispatch = () => {
+/**
+ * 自作hooks
+ *
+ * @return {Dispatch | undefined} ディスパッチャ
+ */
+export const useAuthDispatch = (): Dispatch => {
   const context = useContext(AuthDispatchContext);
   return context;
 };
+interface Props {
+    readonly children: React.ReactNode;
+  }
+
+const AuthProvider: React.FC<Props> = ({children}:Props) => {
+  const [state, dispatch] = useReducer(authReducer, {
+    status: 'Loading',
+  });
+
+  return (
+    <AuthStateContext.Provider value={state}>
+      <AuthDispatchContext.Provider value={dispatch}>
+        {children}
+      </AuthDispatchContext.Provider>
+    </AuthStateContext.Provider>
+  );
+};
+export default AuthProvider;

--- a/src/app/components/molecule/AuthProvider.tsx
+++ b/src/app/components/molecule/AuthProvider.tsx
@@ -1,0 +1,49 @@
+import {createContext, useContext} from 'react';
+
+type State =
+| { status: 'Unauthenticated'; token: string|undefined }
+| { status: 'Loading';}
+| { status: 'Authenticated'; token: string };
+
+type Action =
+| { type: 'START_LOGIN' }
+| { type: 'COMPLETE_LOGIN'; token: string }
+| { type: 'COMPLETE_LOGOUT' };
+
+type Dispatch = (action: Action) => void
+const authReducer = (prevState: State, action: Action): State => {
+  switch (action.type) {
+    case 'START_LOGIN':
+      return {
+        ...prevState,
+        status: 'Loading',
+      };
+    case 'COMPLETE_LOGIN':
+      return {
+        ...prevState,
+        status: 'Authenticated',
+        token: action.token,
+      };
+    case 'COMPLETE_LOGOUT':
+      return {
+        ...prevState,
+        status: 'Unauthenticated',
+        token: undefined,
+      };
+  }
+};
+const AuthStateContext = createContext<State>({
+  status: 'Unauthenticated',
+  token: undefined,
+});
+
+const AuthDispatchContext = createContext<Dispatch | undefined>(undefined);
+export const useAuthState = () => {
+  const context = useContext(AuthStateContext);
+  return context;
+};
+
+export const useAuthDispatch = () => {
+  const context = useContext(AuthDispatchContext);
+  return context;
+};

--- a/src/app/components/pages/ConfirmCodePage.tsx
+++ b/src/app/components/pages/ConfirmCodePage.tsx
@@ -39,7 +39,7 @@ const ConfirmationPage: React.FC<Props> = ({
       ]);
     } catch (err) {
       // 失敗時など
-      Alert.alert('確認失敗', `${JSON.stringify(err)}`);
+      Alert.alert('検証失敗', `${JSON.stringify(err)}`);
     }
   };
 
@@ -69,7 +69,7 @@ const ConfirmationPage: React.FC<Props> = ({
             keyboardType="number-pad"
             value={confirmCode}
             onChangeText={(input) => setConfirmCode(input)}
-            placeholder="確認コード"
+            placeholder="検証コード"
             returnKeyType="done"
             autoCapitalize="none"
           />

--- a/src/app/components/pages/ConfirmCodePage.tsx
+++ b/src/app/components/pages/ConfirmCodePage.tsx
@@ -33,7 +33,7 @@ const ConfirmationPage: React.FC<Props> = ({
   const [confirmCode, setConfirmCode] = useState<string>('');
   const confirmSignUp = async () => {
     try {
-      await new CognitoAuth().confirmSignUp(username, confirmCode);
+      await CognitoAuth.confirmSignUp(username, confirmCode);
       Alert.alert('登録完了', 'ログイン画面に戻ります。', [
         {onPress: () => dispatch(StackActions.popToTop())},
       ]);
@@ -45,7 +45,7 @@ const ConfirmationPage: React.FC<Props> = ({
 
   const resendConfirmationCode = async () => {
     try {
-      await new CognitoAuth().resendConfirmationCode(username);
+      await CognitoAuth.resendConfirmationCode(username);
       Alert.alert('再送しました', '確認してください。');
     } catch (err) {
       // 失敗時など

--- a/src/app/components/pages/HomePage.tsx
+++ b/src/app/components/pages/HomePage.tsx
@@ -6,6 +6,9 @@ import {
 import CognitoAuth from 'src/app/backend/Authn';
 import {useAuthDispatch} from 'src/app/components/molecule/AuthProvider';
 
+import RNPickerSelect from 'react-native-picker-select';
+import MyDatePicker from 'src/app/components/molecule/DatePicker';
+
 const HomePage: React.FC = () => {
   const dispatch = useAuthDispatch();
   const signOut = async () => {
@@ -27,6 +30,17 @@ const HomePage: React.FC = () => {
         title="ログアウト"
         onPress={signOut}
       />
+      <RNPickerSelect
+        doneText={'完了'}
+        onValueChange={(value) => console.log(value)}
+        items={[
+          {label: 'Football', value: 'football'},
+          {label: 'Baseball', value: 'baseball'},
+          {label: 'Hockey', value: 'hockey'},
+        ]}
+      />
+
+      <MyDatePicker />
     </View>
   );
 };

--- a/src/app/components/pages/HomePage.tsx
+++ b/src/app/components/pages/HomePage.tsx
@@ -1,16 +1,33 @@
 import React from 'react';
 import {
   View,
-  Text,
+  Text, Button, Alert,
 } from 'react-native';
+import CognitoAuth from 'src/app/backend/Authn';
+import {useAuthDispatch} from 'src/app/components/molecule/AuthProvider';
 
-const SplashScreen: React.FC = () => {
+const HomePage: React.FC = () => {
+  const dispatch = useAuthDispatch();
+  const signOut = async () => {
+    try {
+      await new CognitoAuth().signOut();
+      dispatch({type: 'COMPLETE_LOGOUT'});
+    } catch (err) {
+    // ログイン失敗時など
+      console.log('Err: ', err);
+      Alert.alert('エラー', JSON.stringify(err));
+    }
+  };
   return (
     <View style={{flex: 1, alignItems: 'center',
       justifyContent: 'center'}}>
       <Text>Hello World</Text>
       <Text>Home</Text>
+      <Button
+        title="ログアウト"
+        onPress={signOut}
+      />
     </View>
   );
 };
-export default SplashScreen;
+export default HomePage;

--- a/src/app/components/pages/HomePage.tsx
+++ b/src/app/components/pages/HomePage.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import {
+  View,
+  Text,
+} from 'react-native';
+
+const SplashScreen: React.FC = () => {
+  return (
+    <View style={{flex: 1, alignItems: 'center',
+      justifyContent: 'center'}}>
+      <Text>Hello World</Text>
+      <Text>Home</Text>
+    </View>
+  );
+};
+export default SplashScreen;

--- a/src/app/components/pages/HomePage.tsx
+++ b/src/app/components/pages/HomePage.tsx
@@ -12,14 +12,25 @@ import MyDatePicker from 'src/app/components/molecule/DatePicker';
 const HomePage: React.FC = () => {
   const dispatch = useAuthDispatch();
   const signOut = async () => {
-    try {
-      await new CognitoAuth().signOut();
-      dispatch({type: 'COMPLETE_LOGOUT'});
-    } catch (err) {
-    // ログイン失敗時など
-      console.log('Err: ', err);
-      Alert.alert('エラー', JSON.stringify(err));
-    }
+    Alert.alert(
+        '確認',
+        'ログアウトしますか',
+        [
+          {
+            text: 'はい',
+            onPress: async () => {
+              // FIXME: onPress内のエラーハンドリングがない
+              await new CognitoAuth().signOut();
+              dispatch({type: 'COMPLETE_LOGOUT'});
+            },
+            style: 'default',
+          },
+          {
+            text: 'いいえ',
+            style: 'cancel',
+          },
+        ],
+    );
   };
   return (
     <View style={{flex: 1, alignItems: 'center',

--- a/src/app/components/pages/HomePage.tsx
+++ b/src/app/components/pages/HomePage.tsx
@@ -20,7 +20,7 @@ const HomePage: React.FC = () => {
             text: 'はい',
             onPress: async () => {
               // FIXME: onPress内のエラーハンドリングがない
-              await new CognitoAuth().signOut();
+              await CognitoAuth.signOut();
               dispatch({type: 'COMPLETE_LOGOUT'});
             },
             style: 'default',

--- a/src/app/components/pages/MfaPage.tsx
+++ b/src/app/components/pages/MfaPage.tsx
@@ -15,6 +15,7 @@ import {
 import CognitoAuth from 'src/app/backend/Authn';
 import {RouteProp} from '@react-navigation/native';
 import {RootStackParamList} from './Navigator';
+import {useAuthDispatch} from 'src/app/components/molecule/AuthProvider';
 
 // Stack Navigation
 type ConfirmationPageRouteProp = RouteProp<RootStackParamList, 'Mfa'>;
@@ -27,19 +28,19 @@ const {width} = Dimensions.get('window'); // get window size
 
 const MfaPage: React.FC<Props> = ({
   route,
-  navigation: {dispatch},
 }: Props) => {
-  const {phoneNumber, user} = route.params;
+  const {phoneNumber} = route.params;
   const [confirmCode, setConfirmCode] = useState<string>('');
+  const dispatch = useAuthDispatch();
   const respondToAuthChallenge = async () => {
     try {
-      await CognitoAuth.respondToAuthChallenge(user, confirmCode);
-      // Alert.alert('登録完了', 'ログイン画面に戻ります。', [
-      //   {onPress: () => dispatch(StackActions.popToTop())},
-      // ]);
+      await CognitoAuth.respondToAuthChallenge(confirmCode);
+      // ログイン成功
+      // FIXME トークンを入れるインタフェースになっているが、不要な気がする
+      dispatch({type: 'COMPLETE_LOGIN', token: 'DUMMY'});
     } catch (err) {
       // 失敗時など
-      Alert.alert('確認失敗', `${JSON.stringify(err)}`);
+      Alert.alert('認証失敗', `${JSON.stringify(err)}`);
     }
   };
 

--- a/src/app/components/pages/MfaPage.tsx
+++ b/src/app/components/pages/MfaPage.tsx
@@ -1,0 +1,89 @@
+import React, {useState} from 'react';
+import {
+  View,
+  Text,
+  KeyboardAvoidingView,
+  TextInput,
+  TouchableWithoutFeedback,
+  Keyboard,
+  Platform,
+  StyleSheet,
+  Button,
+  Alert,
+  Dimensions,
+} from 'react-native';
+import CognitoAuth from 'src/app/backend/Authn';
+import {RouteProp, StackActions} from '@react-navigation/native';
+import {RootStackParamList} from './Navigator';
+
+// Stack Navigation
+type ConfirmationPageRouteProp = RouteProp<RootStackParamList, 'Mfa'>;
+interface Props {
+  route: ConfirmationPageRouteProp;
+  navigation: any;
+}
+
+const {width} = Dimensions.get('window'); // get window size
+
+const MfaPage: React.FC<Props> = ({
+  route,
+  navigation: {dispatch},
+}: Props) => {
+  const {phoneNumber, user} = route.params;
+  const [confirmCode, setConfirmCode] = useState<string>('');
+  const respondToAuthChallenge = async () => {
+    try {
+      await new CognitoAuth().respondToAuthChallenge(user, confirmCode);
+      // Alert.alert('登録完了', 'ログイン画面に戻ります。', [
+      //   {onPress: () => dispatch(StackActions.popToTop())},
+      // ]);
+    } catch (err) {
+      // 失敗時など
+      Alert.alert('確認失敗', `${JSON.stringify(err)}`);
+    }
+  };
+
+  return (
+    <KeyboardAvoidingView
+      behavior={Platform.OS == 'ios' ? 'padding' : 'height'}
+      style={styles.container}
+    >
+      <TouchableWithoutFeedback onPress={() => Keyboard.dismiss()}>
+        <View
+          style={{flex: 1, alignItems: 'center', justifyContent: 'center'}}
+        >
+          <Text>MFA</Text>
+          <Text>検証コードを送信:{phoneNumber}</Text>
+
+          <TextInput
+            style={styles.formControl}
+            keyboardType="number-pad"
+            value={confirmCode}
+            onChangeText={(input) => setConfirmCode(input)}
+            placeholder="確認コード"
+            returnKeyType="done"
+            autoCapitalize="none"
+          />
+          <Button title="確認" onPress={respondToAuthChallenge} />
+          {/* <Button title="再送" onPress={resendConfirmationCode} /> */}
+        </View>
+      </TouchableWithoutFeedback>
+    </KeyboardAvoidingView>
+  );
+};
+
+export default MfaPage;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  formControl: {
+    height: 40,
+    width: width * 0.8,
+    padding: 8,
+    marginBottom: 8,
+    borderColor: 'gray',
+    borderWidth: 1,
+  },
+});

--- a/src/app/components/pages/MfaPage.tsx
+++ b/src/app/components/pages/MfaPage.tsx
@@ -54,16 +54,17 @@ const MfaPage: React.FC<Props> = ({
           style={{flex: 1, alignItems: 'center', justifyContent: 'center'}}
         >
           <Text>MFA</Text>
-          <Text>検証コードを送信:{phoneNumber}</Text>
+          <Text>認証コードを送信:{phoneNumber}</Text>
 
           <TextInput
             style={styles.formControl}
             keyboardType="number-pad"
             value={confirmCode}
             onChangeText={(input) => setConfirmCode(input)}
-            placeholder="確認コード"
+            placeholder="認証コード"
             returnKeyType="done"
             autoCapitalize="none"
+            secureTextEntry={true}
           />
           <Button title="確認" onPress={respondToAuthChallenge} />
           {/* <Button title="再送" onPress={resendConfirmationCode} /> */}

--- a/src/app/components/pages/MfaPage.tsx
+++ b/src/app/components/pages/MfaPage.tsx
@@ -13,7 +13,7 @@ import {
   Dimensions,
 } from 'react-native';
 import CognitoAuth from 'src/app/backend/Authn';
-import {RouteProp, StackActions} from '@react-navigation/native';
+import {RouteProp} from '@react-navigation/native';
 import {RootStackParamList} from './Navigator';
 
 // Stack Navigation
@@ -33,7 +33,7 @@ const MfaPage: React.FC<Props> = ({
   const [confirmCode, setConfirmCode] = useState<string>('');
   const respondToAuthChallenge = async () => {
     try {
-      await new CognitoAuth().respondToAuthChallenge(user, confirmCode);
+      await CognitoAuth.respondToAuthChallenge(user, confirmCode);
       // Alert.alert('登録完了', 'ログイン画面に戻ります。', [
       //   {onPress: () => dispatch(StackActions.popToTop())},
       // ]);

--- a/src/app/components/pages/Navigator.tsx
+++ b/src/app/components/pages/Navigator.tsx
@@ -1,13 +1,18 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import {
   createStackNavigator,
 } from '@react-navigation/stack';
 import {CognitoUser} from 'amazon-cognito-identity-js';
+import CognitoAuth from 'src/app/backend/Authn';
 
 import SignInPage from 'src/app/components/pages/SignInPage';
 import SignUpPage from 'src/app/components/pages/SignUpPage';
 import ConfirmCodePage from 'src/app/components/pages/ConfirmCodePage';
+import SplashScreen from 'src/app/components/pages/SplashScreen';
+import HomePage from 'src/app/components/pages/HomePage';
 import MfaPage from 'src/app/components/pages/MfaPage';
+import {useAuthState,
+  useAuthDispatch} from 'src/app/components/molecule/AuthProvider';
 
 export type RootStackParamList = {
   SignUp: { username: string };
@@ -16,30 +21,52 @@ export type RootStackParamList = {
 
 const Stack = createStackNavigator();
 const Navigator: React.FC = () => {
-  return (
-    <Stack.Navigator initialRouteName="SignIn">
-      <Stack.Screen
-        name="SignIn"
-        component={SignInPage}
-        options={{title: 'ログイン'}}
-      />
-      <Stack.Screen
-        name="SignUp"
-        component={SignUpPage}
-        options={{title: '新規登録'}}
-      />
-      <Stack.Screen
-        name="ConfirmCode"
-        component={ConfirmCodePage}
-        options={{title: '確認コード入力'}}
-      />
-      <Stack.Screen
-        name="MfaAuthn"
-        component={MfaPage}
-        options={{title: '認証コード入力'}}
-      />
-    </Stack.Navigator>
-  );
+  const state = useAuthState();
+  const dispatch = useAuthDispatch();
+
+  // 初期起動時の認証状態を元に、遷移先を決める
+  useEffect( () => {
+    async function isAuthorized() {
+      if (await new CognitoAuth().currentSession()) {
+        dispatch({type: 'COMPLETE_LOGIN', token: 'dummy-token'});
+      } else {
+        dispatch({type: 'COMPLETE_LOGOUT'});
+      }
+    }
+    isAuthorized();
+  }, [dispatch]);
+
+
+  if (state.status === 'Loading') {
+    return <SplashScreen />;
+  } else if (state.status === 'Authenticated') {
+    return <HomePage />;
+  } else {
+    return (
+      <Stack.Navigator initialRouteName="SignIn">
+        <Stack.Screen
+          name="SignIn"
+          component={SignInPage}
+          options={{title: 'ログイン'}}
+        />
+        <Stack.Screen
+          name="SignUp"
+          component={SignUpPage}
+          options={{title: '新規登録'}}
+        />
+        <Stack.Screen
+          name="ConfirmCode"
+          component={ConfirmCodePage}
+          options={{title: '確認コード入力'}}
+        />
+        <Stack.Screen
+          name="MfaAuthn"
+          component={MfaPage}
+          options={{title: '認証コード入力'}}
+        />
+      </Stack.Navigator>
+    );
+  }
 };
 
 export default Navigator;

--- a/src/app/components/pages/Navigator.tsx
+++ b/src/app/components/pages/Navigator.tsx
@@ -2,7 +2,6 @@ import React, {useEffect} from 'react';
 import {
   createStackNavigator,
 } from '@react-navigation/stack';
-import {CognitoUser} from 'amazon-cognito-identity-js';
 import CognitoAuth from 'src/app/backend/Authn';
 
 import SignInPage from 'src/app/components/pages/SignInPage';
@@ -16,7 +15,7 @@ import {useAuthState,
 
 export type RootStackParamList = {
   SignUp: { username: string };
-  Mfa: { phoneNumber: string, user: CognitoUser };
+  Mfa: { phoneNumber: string };
 };
 
 const Stack = createStackNavigator();

--- a/src/app/components/pages/Navigator.tsx
+++ b/src/app/components/pages/Navigator.tsx
@@ -27,7 +27,7 @@ const Navigator: React.FC = () => {
   // 初期起動時の認証状態を元に、遷移先を決める
   useEffect( () => {
     async function isAuthorized() {
-      if (await new CognitoAuth().currentSession()) {
+      if (await CognitoAuth.currentSession()) {
         dispatch({type: 'COMPLETE_LOGIN', token: 'dummy-token'});
       } else {
         dispatch({type: 'COMPLETE_LOGOUT'});

--- a/src/app/components/pages/Navigator.tsx
+++ b/src/app/components/pages/Navigator.tsx
@@ -2,13 +2,16 @@ import React from 'react';
 import {
   createStackNavigator,
 } from '@react-navigation/stack';
+import {CognitoUser} from 'amazon-cognito-identity-js';
 
-import SignInPage from './SignInPage';
-import SignUpPage from './SignUpPage';
-import ConfirmCodePage from './ConfirmCodePage';
+import SignInPage from 'src/app/components/pages/SignInPage';
+import SignUpPage from 'src/app/components/pages/SignUpPage';
+import ConfirmCodePage from 'src/app/components/pages/ConfirmCodePage';
+import MfaPage from 'src/app/components/pages/MfaPage';
 
 export type RootStackParamList = {
   SignUp: { username: string };
+  Mfa: { phoneNumber: string, user: CognitoUser };
 };
 
 const Stack = createStackNavigator();
@@ -29,6 +32,11 @@ const Navigator: React.FC = () => {
         name="ConfirmCode"
         component={ConfirmCodePage}
         options={{title: '確認コード入力'}}
+      />
+      <Stack.Screen
+        name="MfaAuthn"
+        component={MfaPage}
+        options={{title: '認証コード入力'}}
       />
     </Stack.Navigator>
   );

--- a/src/app/components/pages/SignInPage.tsx
+++ b/src/app/components/pages/SignInPage.tsx
@@ -31,7 +31,6 @@ const SignInPage: React.FC<Props> = ({navigation: {navigate}}: Props) => {
   const [secure, setSecure] = useState<boolean>(true);
   const signIn = async () => {
     try {
-      await new CognitoAuth().currentSession();
       const user = await new CognitoAuth().signIn(username, password);
       const authUser: CognitoUser = user;
       const userSession = authUser.getSignInUserSession();

--- a/src/app/components/pages/SignInPage.tsx
+++ b/src/app/components/pages/SignInPage.tsx
@@ -15,8 +15,6 @@ import {
 } from 'react-native';
 import CognitoAuth from 'src/app/backend/Authn';
 import {useAuthDispatch} from 'src/app/components/molecule/AuthProvider';
-import RNPickerSelect from 'react-native-picker-select';
-import MyDatePicker from 'src/app/components/molecule/DatePicker';
 import Icon from 'react-native-vector-icons/Ionicons';
 
 // Stack Navigation
@@ -104,17 +102,6 @@ const SignInPage: React.FC<Props> = ({navigation: {navigate}}: Props) => {
           </View>
           <Button title="ログイン" onPress={signIn} />
           <Button title="新規登録" onPress={() => navigate('SignUp')} />
-          <RNPickerSelect
-            doneText={'完了'}
-            onValueChange={(value) => console.log(value)}
-            items={[
-              {label: 'Football', value: 'football'},
-              {label: 'Baseball', value: 'baseball'},
-              {label: 'Hockey', value: 'hockey'},
-            ]}
-          />
-
-          <MyDatePicker />
         </View>
       </TouchableWithoutFeedback>
     </KeyboardAvoidingView>

--- a/src/app/components/pages/SignInPage.tsx
+++ b/src/app/components/pages/SignInPage.tsx
@@ -14,6 +14,7 @@ import {
   Dimensions,
 } from 'react-native';
 import CognitoAuth from 'src/app/backend/Authn';
+import {useAuthDispatch} from 'src/app/components/molecule/AuthProvider';
 import RNPickerSelect from 'react-native-picker-select';
 import MyDatePicker from 'src/app/components/molecule/DatePicker';
 import Icon from 'react-native-vector-icons/Ionicons';
@@ -29,6 +30,7 @@ const SignInPage: React.FC<Props> = ({navigation: {navigate}}: Props) => {
   const [username, setUsername] = useState<string>('');
   const [password, setPassword] = useState<string>('');
   const [secure, setSecure] = useState<boolean>(true);
+  const dispatch = useAuthDispatch();
   const signIn = async () => {
     try {
       const user = await new CognitoAuth().signIn(username, password);
@@ -36,10 +38,8 @@ const SignInPage: React.FC<Props> = ({navigation: {navigate}}: Props) => {
       const userSession = authUser.getSignInUserSession();
       if (userSession) {
         // ログイン成功
-        Alert.alert('ログイン完了');
-        // console.log("AccessToken", userSession.getAccessToken());
-        // console.log("IdToken", userSession.getIdToken());
-        // console.log("RefleshToken", userSession.getRefreshToken());
+        // FIXME トークンを入れるインタフェースになっているが、不要な気がする
+        dispatch({type: 'COMPLETE_LOGIN', token: 'DUMMY'});
       } else if (user.challengeName && user.challengeName == 'SMS_MFA') {
         // チャレンジ(MFA)
         // console.log("USER", user);

--- a/src/app/components/pages/SignInPage.tsx
+++ b/src/app/components/pages/SignInPage.tsx
@@ -31,7 +31,7 @@ const SignInPage: React.FC<Props> = ({navigation: {navigate}}: Props) => {
   const [secure, setSecure] = useState<boolean>(true);
   const signIn = async () => {
     try {
-      // await new CognitoAuth().currentSession();
+      await new CognitoAuth().currentSession();
       const user = await new CognitoAuth().signIn(username, password);
       const authUser: CognitoUser = user;
       const userSession = authUser.getSignInUserSession();
@@ -48,7 +48,8 @@ const SignInPage: React.FC<Props> = ({navigation: {navigate}}: Props) => {
         console.log('challengeName', user.challengeName);
         const {CODE_DELIVERY_DESTINATION: phoneNumber} = user.challengeParam;
         console.log('DESTINATION', phoneNumber);
-        Alert.alert('検証コードを送信', `送信先:${phoneNumber}`);
+        navigate('MfaAuthn', {phoneNumber, authUser});
+        // Alert.alert('検証コードを送信', `送信先:${phoneNumber}`);
       } else {
         // それ以外の場合は想定外なのでエラー
         throw Error;
@@ -58,7 +59,6 @@ const SignInPage: React.FC<Props> = ({navigation: {navigate}}: Props) => {
       console.log('Err: ', err);
       Alert.alert('エラー', JSON.stringify(err));
     }
-    // Alert.alert(`Simple Button pressed:${username}`);
   };
 
   return (

--- a/src/app/components/pages/SignInPage.tsx
+++ b/src/app/components/pages/SignInPage.tsx
@@ -40,12 +40,11 @@ const SignInPage: React.FC<Props> = ({navigation: {navigate}}: Props) => {
         dispatch({type: 'COMPLETE_LOGIN', token: 'DUMMY'});
       } else if (user.challengeName && user.challengeName == 'SMS_MFA') {
         // チャレンジ(MFA)
-        // console.log("USER", user);
         console.log('SESSION', user.Session);
         console.log('challengeName', user.challengeName);
         const {CODE_DELIVERY_DESTINATION: phoneNumber} = user.challengeParam;
         console.log('DESTINATION', phoneNumber);
-        navigate('MfaAuthn', {phoneNumber, authUser});
+        navigate('MfaAuthn', {phoneNumber});
         // Alert.alert('検証コードを送信', `送信先:${phoneNumber}`);
       } else {
         // それ以外の場合は想定外なのでエラー

--- a/src/app/components/pages/SignInPage.tsx
+++ b/src/app/components/pages/SignInPage.tsx
@@ -31,7 +31,7 @@ const SignInPage: React.FC<Props> = ({navigation: {navigate}}: Props) => {
   const dispatch = useAuthDispatch();
   const signIn = async () => {
     try {
-      const user = await new CognitoAuth().signIn(username, password);
+      const user = await CognitoAuth.signIn(username, password);
       const authUser: CognitoUser = user;
       const userSession = authUser.getSignInUserSession();
       if (userSession) {

--- a/src/app/components/pages/SignUpPage.tsx
+++ b/src/app/components/pages/SignUpPage.tsx
@@ -32,7 +32,7 @@ const SignUpPage: React.FC<Props> = ({navigation: {navigate}}: Props) => {
   });
   const signUp = async () => {
     try {
-      await new CognitoAuth().signUp(form);
+      await CognitoAuth.signUp(form);
       navigate('ConfirmCode', {username: form.username}); // 型が適当
     } catch (err) {
       // 失敗時など

--- a/src/app/components/pages/SplashScreen.tsx
+++ b/src/app/components/pages/SplashScreen.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import {
+  View,
+  Text,
+} from 'react-native';
+
+const SplashScreen: React.FC = () => {
+  return (
+    <View style={{flex: 1, alignItems: 'center',
+      justifyContent: 'center'}}>
+      <Text>Hello World</Text>
+      <Text>Splash Screen</Text>
+    </View>
+  );
+};
+export default SplashScreen;


### PR DESCRIPTION
React Navigationの認証フローを適用しました。
⚠リファクタできそうな項目があるため、`FIXME`をつけたうえでマージします。

# 追加項目
- 認証に関する状態を３状態で定義し、それぞれで遷移できるページを定義
  - ログイン済：ホーム画面
  - 未ログイン：ログイン画面（ならびに、その他ユーザ登録系）
  - 確認中(Loading)：スプラッシュ画面

- SMSによるMFAコード検証画面を追加

# 参考ページ
- [React Navigation公式](https://reactnavigation.org/docs/auth-flow/#implement-the-logic-for-restoring-the-token)
- [React Navigation v5 が推奨する認証フローの実装](https://qiita.com/dhythm/items/9ba34ad1bc5f89a49463)
